### PR TITLE
feat(league): 리그 시즌 업데이트 스케쥴러 구현

### DIFF
--- a/src/main/java/com/ksy/fmrs/domain/League.java
+++ b/src/main/java/com/ksy/fmrs/domain/League.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -44,6 +45,12 @@ public class League {
 
     private Boolean standing;
 
+    @Column(name = "start_date")
+    private LocalDate startDate;
+
+    @Column(name = "end_date")
+    private LocalDate endDate;
+
     @Builder
     public League(Integer leagueApiId, String name, String nationName, String nationLogoUrl, Integer currentSeason, String logoUrl, LeagueType leagueType, Boolean standing) {
         this.leagueApiId = leagueApiId;
@@ -63,5 +70,17 @@ public class League {
         this.nationLogoUrl = nationImageUrl;
         this.currentSeason = currentSeason;
         this.logoUrl = logoUrl;
+    }
+
+    public void updateStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    public void updateEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    public void updateCurrentSeason(Integer currentSeason) {
+        this.currentSeason = currentSeason;
     }
 }

--- a/src/main/java/com/ksy/fmrs/dto/apiFootball/LeagueApiResponseDto.java
+++ b/src/main/java/com/ksy/fmrs/dto/apiFootball/LeagueApiResponseDto.java
@@ -1,7 +1,10 @@
 package com.ksy.fmrs.dto.apiFootball;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -43,8 +46,13 @@ public record LeagueApiResponseDto(
 
     public record Season(
             int year,
-            String start,
-            String end,
+            @JsonProperty("start")
+            @JsonFormat(pattern = "yyyy-MM-dd")
+            LocalDate start,
+
+            @JsonProperty("end")
+            @JsonFormat(pattern = "yyyy-MM-dd")
+            LocalDate end,
             boolean current,
             Coverage coverage
     ) {}

--- a/src/main/java/com/ksy/fmrs/dto/league/LeagueAPIDetailsResponseDto.java
+++ b/src/main/java/com/ksy/fmrs/dto/league/LeagueAPIDetailsResponseDto.java
@@ -4,10 +4,12 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDate;
+
 @Getter
 @Setter
 @Builder
-public class LeagueDetailsRequestDto {
+public class LeagueAPIDetailsResponseDto {
 
     private Integer leagueApiId;
     private String leagueName;
@@ -17,4 +19,6 @@ public class LeagueDetailsRequestDto {
     private String leagueType;
     private Integer currentSeason;
     private Boolean Standing;
+    private LocalDate startDate;
+    private LocalDate endDate;
 }

--- a/src/main/java/com/ksy/fmrs/dto/league/LeagueDetailsResponseDto.java
+++ b/src/main/java/com/ksy/fmrs/dto/league/LeagueDetailsResponseDto.java
@@ -9,8 +9,9 @@ import lombok.Setter;
 @Setter
 @Builder
 public class LeagueDetailsResponseDto {
-    private Integer leagueApiId;
+
     private String name;
+    private Integer leagueApiId;
     private String logoImageUrl;
     private String nationName;
     private String nationImageUrl;

--- a/src/main/java/com/ksy/fmrs/repository/LeagueRepository.java
+++ b/src/main/java/com/ksy/fmrs/repository/LeagueRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -20,4 +21,18 @@ public interface LeagueRepository extends JpaRepository<League, Long> {
     @Query("SELECT l FROM League l " +
             "WHERE l.teams IS EMPTY")
     List<League> findUnassignedLeagues();
+
+    @Query("SELECT l.leagueApiId FROM League l " +
+            "WHERE l.startDate IS NULL" +
+            "   OR l.endDate IS NULL " +
+            "   OR :now < l.startDate " +
+            "   OR :now > l.endDate")
+    List<Integer> findLeaguesApiIdsOutsideSeason(LocalDate now);
+
+    @Query("SELECT l FROM League l " +
+            "WHERE l.startDate IS NULL" +
+            "   OR l.endDate IS NULL " +
+//            "   OR :now < l.startDate " +
+            "   OR :now > l.endDate")
+    List<League> findLeaguesIdsOutsideSeasonV1(LocalDate now);
 }

--- a/src/main/java/com/ksy/fmrs/scheduler/LeagueUpdateScheduler.java
+++ b/src/main/java/com/ksy/fmrs/scheduler/LeagueUpdateScheduler.java
@@ -1,0 +1,29 @@
+package com.ksy.fmrs.scheduler;
+
+import com.ksy.fmrs.service.LeagueService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class LeagueUpdateScheduler {
+    private final LeagueService leagueService;
+
+    @Scheduled(cron = "${init.update_league_time}", zone = "Asia/Seoul")
+    public void updateLeagueSeason(){
+        log.info("start update league season");
+        leagueService.findLeaguesApiIdsOutsideSeason()
+                .forEach(apiIds->{
+                    try {
+                        leagueService.findLeagueApiInfo(apiIds)
+                                .ifPresent(dto->
+                                        leagueService.refreshLeagueSeason(apiIds, dto));
+                    } catch (Exception e) {
+                       log.info("fail to update league season : leagueApiId ={}", apiIds);
+                    }
+                });
+    }
+}

--- a/src/main/java/com/ksy/fmrs/service/FootballApiService.java
+++ b/src/main/java/com/ksy/fmrs/service/FootballApiService.java
@@ -6,7 +6,7 @@ import com.ksy.fmrs.domain.player.PlayerStat;
 import com.ksy.fmrs.domain.enums.UrlEnum;
 import com.ksy.fmrs.dto.apiFootball.*;
 import com.ksy.fmrs.dto.apiFootball.LeagueApiResponseDto;
-import com.ksy.fmrs.dto.league.LeagueDetailsRequestDto;
+import com.ksy.fmrs.dto.league.LeagueAPIDetailsResponseDto;
 import com.ksy.fmrs.dto.player.PlayerSimpleDto;
 import com.ksy.fmrs.dto.player.PlayerStatDto;
 import com.ksy.fmrs.dto.team.TeamStatisticsDto;
@@ -101,7 +101,7 @@ public class FootballApiService {
         return convertStatisticsToTeamDetailsDto(response, currentSeason);
     }
 
-    public Mono<Optional<LeagueDetailsRequestDto>> getLeagueInfo(Integer leagueApiId) {
+    public Mono<Optional<LeagueAPIDetailsResponseDto>> getLeagueInfo(Integer leagueApiId) {
         return Objects.requireNonNull(webClientService.
                 getApiResponse(UrlEnum.buildLeagueUrl(leagueApiId), LeagueApiResponseDto.class))
                 .map(this::convertToLeagueInfoDto);
@@ -244,7 +244,7 @@ public class FootballApiService {
                 .build();
     }
 
-    private Optional<LeagueDetailsRequestDto> convertToLeagueInfoDto(LeagueApiResponseDto leagueApiResponseDto) {
+    private Optional<LeagueAPIDetailsResponseDto> convertToLeagueInfoDto(LeagueApiResponseDto leagueApiResponseDto) {
         // 응답 리스트가 null이거나 비어 있으면 Optional.empty() 반환
         if (leagueApiResponseDto.response() == null || leagueApiResponseDto.response().isEmpty()) {
             return Optional.empty();
@@ -259,7 +259,7 @@ public class FootballApiService {
         LeagueApiResponseDto.Country country = firstResponse.country();
         List<LeagueApiResponseDto.Season> seasons = firstResponse.seasons();
         LeagueApiResponseDto.Season season = seasons.getLast();
-        LeagueDetailsRequestDto dto = LeagueDetailsRequestDto.builder()
+        LeagueAPIDetailsResponseDto dto = LeagueAPIDetailsResponseDto.builder()
                 .leagueApiId(league.id())
                 .currentSeason(season.year())
                 .leagueName(league.name())
@@ -268,6 +268,8 @@ public class FootballApiService {
                 .nationName(country.name())
                 .nationImageUrl(country.flag())
                 .Standing(season.coverage().standings())
+                .startDate(season.start())
+                .endDate(season.end())
                 .build();
         return Optional.of(dto);
     }

--- a/src/main/java/com/ksy/fmrs/service/LeagueService.java
+++ b/src/main/java/com/ksy/fmrs/service/LeagueService.java
@@ -2,24 +2,32 @@ package com.ksy.fmrs.service;
 
 import com.ksy.fmrs.domain.League;
 import com.ksy.fmrs.domain.enums.LeagueType;
-import com.ksy.fmrs.dto.league.LeagueDetailsRequestDto;
+import com.ksy.fmrs.dto.league.LeagueAPIDetailsResponseDto;
 import com.ksy.fmrs.dto.league.LeagueDetailsResponseDto;
 import com.ksy.fmrs.repository.LeagueRepository;
+import com.ksy.fmrs.util.time.TimeProvider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class LeagueService {
 
+    private final FootballApiService footballApiService;
+    private final TimeProvider timeProvider;
     private final LeagueRepository leagueRepository;
 
     @Transactional
-    public void saveAllByLeagueDetails(List<LeagueDetailsRequestDto> leagueDetailsRequestDto) {
-        List<League> allLeague = leagueDetailsRequestDto.stream().map(dto->{
+    public void saveAllByLeagueDetails(List<LeagueAPIDetailsResponseDto> leagueAPIDetailsResponseDto) {
+        List<League> allLeague = leagueAPIDetailsResponseDto.stream().map(dto -> {
             return League.builder()
                     .leagueApiId(dto.getLeagueApiId())
                     .name(dto.getLeagueName())
@@ -35,9 +43,37 @@ public class LeagueService {
         leagueRepository.saveAll(allLeague);
     }
 
+    public Optional<LeagueAPIDetailsResponseDto> findLeagueApiInfo(Integer leagueApiId){
+        return footballApiService
+                .getLeagueInfo(leagueApiId)
+                .blockOptional()
+                .orElseThrow(() -> new IllegalArgumentException("Api 응답 없음"));
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void refreshLeagueSeason(Integer leagueApiId, LeagueAPIDetailsResponseDto dto) {
+        League league = leagueRepository.findLeagueByLeagueApiId(leagueApiId)
+                .orElseThrow(() -> new IllegalArgumentException("League not found apiId: " + leagueApiId));
+
+        updateLeagueSeason(league, dto.getStartDate(), dto.getEndDate(), dto.getCurrentSeason());
+    }
+
+    private void updateLeagueSeason(League league, LocalDate startDate, LocalDate endDate, Integer currentSeason) {
+        league.updateStartDate(startDate);
+        league.updateEndDate(endDate);
+        league.updateCurrentSeason(currentSeason);
+    }
+
+
+    @Transactional(readOnly = true)
+    public List<Integer> findLeaguesApiIdsOutsideSeason() {
+        return leagueRepository
+                .findLeaguesApiIdsOutsideSeason(timeProvider.getCurrentLocalDate());
+    }
+
     public LeagueDetailsResponseDto getLeagueDetails(Long leagueId) {
         League league = leagueRepository.findById(leagueId)
-                .orElseThrow(()-> new IllegalArgumentException("League not found id: " + leagueId));
+                .orElseThrow(() -> new IllegalArgumentException("League not found id: " + leagueId));
         return createLeagueDetailsResponseDtoByLeague(league);
     }
 
@@ -55,10 +91,10 @@ public class LeagueService {
     }
 
     private LeagueType validateLeagueType(String leagueType) {
-        if(leagueType==null){
+        if (leagueType == null) {
             throw new IllegalArgumentException("League type is null");
         }
-        if(leagueType.equals(LeagueType.LEAGUE.getValue())){
+        if (leagueType.equals(LeagueType.LEAGUE.getValue())) {
             return LeagueType.LEAGUE;
         }
         return LeagueType.CUP;

--- a/src/main/java/com/ksy/fmrs/service/ReactiveInitializeService.java
+++ b/src/main/java/com/ksy/fmrs/service/ReactiveInitializeService.java
@@ -7,7 +7,7 @@ import com.ksy.fmrs.domain.enums.LeagueType;
 import com.ksy.fmrs.domain.enums.MappingStatus;
 import com.ksy.fmrs.domain.player.*;
 import com.ksy.fmrs.dto.apiFootball.LeagueApiPlayersDto;
-import com.ksy.fmrs.dto.league.LeagueDetailsRequestDto;
+import com.ksy.fmrs.dto.league.LeagueAPIDetailsResponseDto;
 import com.ksy.fmrs.dto.player.FmPlayerDto;
 import com.ksy.fmrs.repository.BulkRepository;
 import com.ksy.fmrs.repository.LeagueRepository;
@@ -301,11 +301,11 @@ public class ReactiveInitializeService {
         return urls;
     }
 
-    private Boolean isLeagueType(LeagueDetailsRequestDto leagueDetailsRequestDto) {
-        return leagueDetailsRequestDto != null &&
-                leagueDetailsRequestDto.getLeagueType().equals(LeagueType.LEAGUE.getValue()) &&
-                leagueDetailsRequestDto.getCurrentSeason() >= SEASON_2024 &&
-                leagueDetailsRequestDto.getStanding();
+    private Boolean isLeagueType(LeagueAPIDetailsResponseDto leagueAPIDetailsResponseDto) {
+        return leagueAPIDetailsResponseDto != null &&
+                leagueAPIDetailsResponseDto.getLeagueType().equals(LeagueType.LEAGUE.getValue()) &&
+                leagueAPIDetailsResponseDto.getCurrentSeason() >= SEASON_2024 &&
+                leagueAPIDetailsResponseDto.getStanding();
     }
 
     private List<FmPlayerDto> getPlayersFromFmPlayers(String dirPath) {

--- a/src/test/java/com/ksy/fmrs/service/InitializerServiceTest.java
+++ b/src/test/java/com/ksy/fmrs/service/InitializerServiceTest.java
@@ -1,7 +1,7 @@
 package com.ksy.fmrs.service;
 
 import com.ksy.fmrs.domain.enums.LeagueType;
-import com.ksy.fmrs.dto.league.LeagueDetailsRequestDto;
+import com.ksy.fmrs.dto.league.LeagueAPIDetailsResponseDto;
 import com.ksy.fmrs.repository.LeagueRepository;
 import com.ksy.fmrs.repository.Player.PlayerRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -29,7 +29,7 @@ class InitializerServiceTest {
     @DisplayName("리그, 팀 초기 생성 테스트")
     void 메서드명(){
         // given
-        LeagueDetailsRequestDto leagueDetailsRequestDto = LeagueDetailsRequestDto.builder()
+        LeagueAPIDetailsResponseDto leagueAPIDetailsResponseDto = LeagueAPIDetailsResponseDto.builder()
                 .leagueApiId(1)
                 .leagueName("League1")
                 .leagueType(LeagueType.LEAGUE.getValue())

--- a/src/test/java/com/ksy/fmrs/service/LeagueServiceTest.java
+++ b/src/test/java/com/ksy/fmrs/service/LeagueServiceTest.java
@@ -1,0 +1,77 @@
+package com.ksy.fmrs.service;
+
+import com.ksy.fmrs.domain.League;
+import com.ksy.fmrs.dto.league.LeagueAPIDetailsResponseDto;
+import com.ksy.fmrs.repository.LeagueRepository;
+import com.ksy.fmrs.util.time.TimeProvider;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+
+
+@ExtendWith(MockitoExtension.class)
+class LeagueServiceTest {
+
+    @InjectMocks
+    private LeagueService leagueService;
+    @Mock
+    private FootballApiService footballApiService;
+    @Mock
+    private TimeProvider timeProvider;
+    @Mock
+    private LeagueRepository leagueRepository;
+
+    @Test
+    @DisplayName("apiFootball 에서 리그 정보 가져 오기")
+    void success_findLeagueApiInfo() {
+        // given
+        Integer leagueApiId = 1234;
+        LeagueAPIDetailsResponseDto dto = LeagueAPIDetailsResponseDto
+                .builder().build();
+        given(footballApiService.getLeagueInfo(leagueApiId))
+                .willReturn(Mono.just(Optional.of(dto)));
+
+        // when
+        Optional<LeagueAPIDetailsResponseDto> actual = leagueService.findLeagueApiInfo(leagueApiId);
+
+        // then
+        Assertions.assertThat(actual.get()).isEqualTo(dto);
+    }
+
+    @Test
+    @DisplayName("리그 api 정보와 api Id 로 리그 시즌 정보 업데이트")
+    void success_refreshLeagueSeason() {
+        // given
+        Integer leagueApiId = 1234;
+        League league = League.builder().leagueApiId(leagueApiId).build();
+        LocalDate start = LocalDate.of(2024, 8, 14);
+        LocalDate end = LocalDate.of(2025, 8, 21);
+        Integer currentSeason = 2024;
+
+        LeagueAPIDetailsResponseDto dto = LeagueAPIDetailsResponseDto.builder()
+                .startDate(start)
+                .endDate(end)
+                .currentSeason(currentSeason)
+                .build();
+
+        given(leagueRepository.findLeagueByLeagueApiId(leagueApiId))
+                .willReturn(Optional.of(league));
+        // when
+        leagueService.refreshLeagueSeason(leagueApiId, dto);
+
+        // then
+        Assertions.assertThat(league.getStartDate()).isEqualTo(start);
+        Assertions.assertThat(league.getEndDate()).isEqualTo(end);
+        Assertions.assertThat(league.getCurrentSeason()).isEqualTo(currentSeason);
+    }
+}


### PR DESCRIPTION
- 리그 테이블에 시작일 종료일 컬럼 색성

- 업데이트 주기 3일

- 트랜잭션에서 외부 api 호출 제거