### PR TITLE
refactor: SportsDataSyncService 구현체 클래스 명 변경

### DIFF
--- a/src/main/java/com/ksy/fmrs/config/SportsDataSyncConfig.java
+++ b/src/main/java/com/ksy/fmrs/config/SportsDataSyncConfig.java
@@ -1,7 +1,7 @@
 package com.ksy.fmrs.config;
 
 import com.ksy.fmrs.domain.enums.LeagueType;
-import com.ksy.fmrs.service.SportsDataSyncServiceImpl;
+import com.ksy.fmrs.service.ApiFootballSyncService;
 import com.ksy.fmrs.service.SportsDataSyncService;
 import com.ksy.fmrs.service.SportsDataSyncServiceWebFlux;
 import com.ksy.fmrs.repository.LeagueRepository;
@@ -31,7 +31,7 @@ public class SportsDataSyncConfig {
 
     @Bean
     @ConditionalOnProperty(name = "INITIAL_DATA_INSERT", havingValue = "team")
-    public ApplicationRunner initializeClubTeam(SportsDataSyncServiceImpl syncService,
+    public ApplicationRunner initializeClubTeam(ApiFootballSyncService syncService,
                                                 LeagueRepository leagueRepository) {
         return args -> {
             log.info("Initial team insert started");

--- a/src/main/java/com/ksy/fmrs/service/ApiFootballSyncService.java
+++ b/src/main/java/com/ksy/fmrs/service/ApiFootballSyncService.java
@@ -18,7 +18,7 @@ import java.util.stream.IntStream;
 @Slf4j
 @RequiredArgsConstructor
 @Service
-public class SportsDataSyncServiceImpl implements SportsDataSyncService {
+public class ApiFootballSyncService implements SportsDataSyncService {
     private final SyncTemplate syncTemplate;
     @Qualifier("leagueSyncCallback")
     private final SyncCallback<Integer, ApiFootballLeague, League> leagueSyncCallback;


### PR DESCRIPTION
- ApiFootball 에서 sync 하는게 드러나도록 수정

- 추후 다른 api 사용할때 해당 api 이름으로 추가 구현체 생성